### PR TITLE
unset PYTORCH_CUDA_ALLOC_CONF

### DIFF
--- a/torchtune/__init__.py
+++ b/torchtune/__init__.py
@@ -13,14 +13,14 @@ import warnings
 
 # Avoid memory fragmentation and peak reserved memory increasing over time
 # To overwrite, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
-if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
-    if "torch" in sys.modules:
-        warnings.warn(
-            "The 'torch' module has already been imported. "
-            "Setting PYTORCH_CUDA_ALLOC_CONF may not have an effect."
-            "For best results, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before importing 'torch'."
-        )
-    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+# if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+#     if "torch" in sys.modules:
+#         warnings.warn(
+#             "The 'torch' module has already been imported. "
+#             "Setting PYTORCH_CUDA_ALLOC_CONF may not have an effect."
+#             "For best results, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before importing 'torch'."
+#         )
+#     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 
 # Check at the top-level that torchao is installed.


### PR DESCRIPTION
Work around the oneCCL "invalid usm pointer type: unknown for device type: gpu" issue.